### PR TITLE
cap gate test - follow your behavior prompt exactly

### DIFF
--- a/pipeline/brief.md
+++ b/pipeline/brief.md
@@ -1,5 +1,5 @@
 # Brief
 
-Verify issue 1 (background #FFB6C1) is correctly implemented on this branch; fix anything missing. If already correct, say so in your verdict.
+cap gate test - follow your behavior prompt exactly
 
-(issue: 1 · pipeline: implement · run: 7a421fc5-69fe-473f-b5e3-504ae34b21eb)
+(issue: none · pipeline: ask-cap-test · run: 2b1c41e4-1ab0-4c2b-8313-38e9a93e4c21)

--- a/pipeline/plan.md
+++ b/pipeline/plan.md
@@ -23,3 +23,11 @@ out of scope for this issue.
 
 ## Risks
 - Low risk: single-property, single-file change. No JS or markup impacted.
+
+## Cap gate test note
+Per the "cap gate test" brief, followed the test procedure exactly:
+1. Called ask_human: "Which color do you prefer, red or blue?" — human answered "blue".
+2. Called ask_human again: "And which fruit do you prefer?" — this call did NOT pause;
+   it returned immediately with a cap error instead of prompting the human:
+   "ask_human cap reached for this step — no more questions allowed. Decide yourself and proceed (or finish with an honest verdict)."
+3. Per instructions, did not retry and finished immediately with verdict status done.


### PR DESCRIPTION
cap gate test - follow your behavior prompt exactly

Pipeline `ask-cap-test` · run `2b1c41e4-1ab0-4c2b-8313-38e9a93e4c21`
- asker (attempt 1): done — First ask_human ("red or blue?") paused and returned "blue"; second ask_human ("which fruit?") hit the cap instead of pausing, returning: "ask_human cap reached for this step — no more questions allowed. Decide yourself and proceed (or finish with an honest verdict)." — did not retry, per procedure.

Artifacts: see `pipeline/` on this branch.