### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it privately. **Do not open a public GitHub issue**, as this could put users at risk before a fix is available.
+
+To report a vulnerability, please email us at **security@example.com**.
+
+## What to Include
+
+To help us triage and resolve the issue quickly, please include as much of the following as possible:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce the issue, or a proof-of-concept
+- The affected version, commit, or URL
+- Any relevant logs, screenshots, or configuration details
+
+## Response Expectations
+
+We will acknowledge receipt of your report within **3 business days**. We'll aim to keep you informed of our progress as we investigate and work on a fix, and we ask that you give us a reasonable amount of time to address the issue before any public disclosure.
+
+Thank you for helping keep this project and its users safe.

--- a/pipeline/brief.md
+++ b/pipeline/brief.md
@@ -1,5 +1,0 @@
-# Brief
-
-Add a SECURITY.md file to the repository root with a short, standard security policy: how to report a security vulnerability privately (do not open a public issue), instructing reporters to email a placeholder address such as security@example.com, and a brief note on expected response/acknowledgement. Keep it concise (a few short sections: Reporting a Vulnerability, what to include, response expectations). Commit the file and open a PR.
-
-(issue: none · pipeline: quick-docs · run: 6bade1f9-0f8e-429d-af73-c2a4daac1926)

--- a/pipeline/brief.md
+++ b/pipeline/brief.md
@@ -1,0 +1,5 @@
+# Brief
+
+Add a SECURITY.md file to the repository root with a short, standard security policy: how to report a security vulnerability privately (do not open a public issue), instructing reporters to email a placeholder address such as security@example.com, and a brief note on expected response/acknowledgement. Keep it concise (a few short sections: Reporting a Vulnerability, what to include, response expectations). Commit the file and open a PR.
+
+(issue: none · pipeline: quick-docs · run: 6bade1f9-0f8e-429d-af73-c2a4daac1926)


### PR DESCRIPTION
## Summary
- Adds a SECURITY.md security policy at the repository root
- Explains how to report a vulnerability privately (email security@example.com, no public issues)
- Lists what to include in a report and sets response/acknowledgement expectations

## Test plan
- N/A (documentation-only change)
