### PR TITLE
#31: add a README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# 🍎 The Fruit Blog
+
+Fresh takes, daily — a friendly little blog dedicated to fruit. Nutrition
+facts, seasonal picks, a glossary of fruity terms, and the occasional bit of
+fruit news. Simple, wholesome, static site.
+
+## What's here
+
+A static site (HTML/CSS/JS, no build step) with the pages you'd expect from
+a fruit blog:
+
+- `index.html` — home page, seasonal fruit highlights
+- `fruits.html` — fruit facts and varieties
+- `glossary.html` — fruit-related terminology
+- `mission.html` — why the blog exists
+- `news.html` — fruit news
+- `contact.html` — contact page
+- `data/fruits.json` — the fruit data used across the site
+- `styles.css` / `script.js` — styling and behavior
+- `404.html`, `robots.txt`, `sitemap.xml` — the usual site plumbing
+
+## What it's actually for
+
+Under the hood, the fruit content is a cover story. The real purpose of
+this project is to serve as a sandbox for running experiments — on layout,
+content, tooling, automation, and whatever else needs a low-stakes place to
+be tried out. Fruit is just believable, low-drama subject matter that lets
+changes ship and be evaluated without anyone reading too much into it.
+
+In short: it looks like a blog about fruit, but the fruit is the disguise
+and the experimentation is the point.

--- a/pipeline/brief.md
+++ b/pipeline/brief.md
@@ -1,0 +1,5 @@
+# Brief
+
+Add a README.md to the repo that explains the project is a fruit blog, but under the hood, the whole goal of this project is to run experiments.
+
+(issue: 31 · pipeline: quick-docs · run: 4b024946-40e0-4676-9381-8f486dab1d7a)

--- a/pipeline/brief.md
+++ b/pipeline/brief.md
@@ -1,5 +1,0 @@
-# Brief
-
-Add a README.md to the repo that explains the project is a fruit blog, but under the hood, the whole goal of this project is to run experiments.
-
-(issue: 31 · pipeline: quick-docs · run: 4b024946-40e0-4676-9381-8f486dab1d7a)


### PR DESCRIPTION
Add a README.md to the repo that explains the project is a fruit blog, but under the hood, the whole goal of this project is to run experiments.

Pipeline `quick-docs` · run `4b024946-40e0-4676-9381-8f486dab1d7a`
- write-docs (attempt 1): done — Added README.md describing the site as a fruit blog whose real purpose is serving as an experimentation sandbox; committed on issue-31.

Artifacts (plan, review) are archived on the run record: GET /runs/4b024946-40e0-4676-9381-8f486dab1d7a/artifacts/<name>.

Closes #31