### PR TITLE
Add a new markdown file docs/fruits.md that lists all types of fruits th

### DIFF
--- a/docs/fruits.md
+++ b/docs/fruits.md
@@ -1,0 +1,95 @@
+# 🍓 Fruit Reference
+
+A categorized list of fruits — what's currently featured on The Fruit Blog,
+plus a broader reference of common fruit types the site could plausibly
+cover down the line. Fruits on the site today are pulled from
+[`data/fruits.json`](../data/fruits.json) and marked with ✅.
+
+## Citrus
+
+Bright, acidic fruits from the genus *Citrus*.
+
+- ✅ Orange
+- ✅ Lemon
+- ✅ Lime
+- Grapefruit
+- Mandarin / Tangerine
+- Clementine
+- Pomelo
+- Yuzu
+- Kumquat
+
+## Berries
+
+Small, juicy fruits, often clustered or growing on shrubs/vines.
+
+- ✅ Strawberry
+- ✅ Blueberry
+- Raspberry
+- Blackberry
+- Cranberry
+- Gooseberry
+- Elderberry
+- Currant (red, black, white)
+
+## Stone Fruits
+
+Fruits with a single hard pit (drupes).
+
+- ✅ Cherry
+- ✅ Peach
+- Plum
+- Apricot
+- Nectarine
+- Mango *(botanically a drupe — also listed under Tropical)*
+
+## Tropical
+
+Fruits native to warm, tropical climates.
+
+- ✅ Mango
+- ✅ Pineapple
+- Banana
+- Papaya
+- Guava
+- Passion Fruit
+- Dragon Fruit
+- Lychee
+- Kiwi
+- Coconut
+
+## Melons
+
+Large, water-rich fruits from the gourd family.
+
+- Watermelon
+- Cantaloupe
+- Honeydew
+
+## Pome Fruits
+
+Fruits with a central core containing multiple seeds.
+
+- Apple
+- Pear
+- Quince
+
+## Vine & Cluster Fruits
+
+Fruits that grow in clusters, often on vines.
+
+- ✅ Grape
+- Currant *(see also Berries)*
+
+## Other / Less Common
+
+Fruits that don't fit neatly into the categories above.
+
+- Fig
+- Pomegranate
+- Persimmon
+- Star Fruit (Carambola)
+- Jackfruit
+- Durian
+- Tamarind
+- Plantain

--- a/pipeline/brief.md
+++ b/pipeline/brief.md
@@ -1,5 +1,0 @@
-# Brief
-
-Add a new markdown file docs/fruits.md that lists all types of fruits the fruitBlog site currently has (check existing fruits data file/content in the repo) and/or could plausibly have (a broader reference list of common fruit types/categories). Organize clearly (e.g. by category such as citrus, berries, stone fruits, tropical, melons, etc.), use headings and bullet lists, and keep it consistent with the site's existing docs style if any.
-
-(issue: none · pipeline: quick-docs · run: 99cf98ed-9db8-409d-ace6-65fd0a62bc04)

--- a/pipeline/brief.md
+++ b/pipeline/brief.md
@@ -1,0 +1,5 @@
+# Brief
+
+Add a new markdown file docs/fruits.md that lists all types of fruits the fruitBlog site currently has (check existing fruits data file/content in the repo) and/or could plausibly have (a broader reference list of common fruit types/categories). Organize clearly (e.g. by category such as citrus, berries, stone fruits, tropical, melons, etc.), use headings and bullet lists, and keep it consistent with the site's existing docs style if any.
+
+(issue: none · pipeline: quick-docs · run: 99cf98ed-9db8-409d-ace6-65fd0a62bc04)


### PR DESCRIPTION
Add a new markdown file docs/fruits.md that lists all types of fruits the fruitBlog site currently has (check existing fruits data file/content in the repo) and/or could plausibly have (a broader reference list of common fruit types/categories). Organize clearly (e.g. by category such as citrus, berries, stone fruits, tropical, melons, etc.), use headings and bullet lists, and keep it consistent with the site's existing docs style if any.

Pipeline `quick-docs` · run `99cf98ed-9db8-409d-ace6-65fd0a62bc04`
- write-docs (attempt 1): done — Added docs/fruits.md categorizing the site's current fruits (from data/fruits.json) plus a broader reference list by category (citrus, berries, stone fruits, tropical, melons, pome, vine, other), committed to task-d6195741.

Artifacts (plan, review) are archived on the run record: GET /runs/99cf98ed-9db8-409d-ace6-65fd0a62bc04/artifacts/<name>.